### PR TITLE
Fix: Append => Clean => Append Out of range

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -40,6 +40,9 @@ func (q *Queue) Clean() {
 	q.items = make(map[int64]interface{})
 	q.ids = make(map[interface{}]int64)
 	q.buf = make([]int64, minQueueLen)
+	q.tail = 0
+	q.head = 0
+	q.count = 0
 }
 
 // Returns the number of elements in queue

--- a/queue_test.go
+++ b/queue_test.go
@@ -347,6 +347,20 @@ func TestTestQueueClean(t *testing.T) {
 	}
 }
 
+func TestTestQueueClean2(t *testing.T) {
+	q := New()
+
+	for i := 0; i < 50; i++ {
+		q.Append(i)
+	}
+
+	q.Clean()
+
+	for i := 0; i < 50; i++ {
+		q.Append(i)
+	}
+}
+
 // General warning: Go's benchmark utility (go test -bench .) increases the number of
 // iterations until the benchmarks take a reasonable amount of time to run; memory usage
 // is *NOT* considered. On my machine, these benchmarks hit around ~1GB before they've had


### PR DESCRIPTION
I fixed the index out of range error when I did Append, Clean, and Append.

------------
Issue Code
------------
```golang
package main

import (
	"github.com/sheerun/queue"
)

func main() {
	q := queue.New()

	for i := 0; i < 50; i++ {
		q.Append(i)
	}
	q.Clean()
	for i := 0; i < 50; i++ {
		q.Append(i) // Out of Range!
	}
}
```